### PR TITLE
Bugfix: Error Handling in API call recent data

### DIFF
--- a/src/app/modules/portal/pages/purchase-order/pages/upsert-purchase-order/upsert-purchase-order.component.ts
+++ b/src/app/modules/portal/pages/purchase-order/pages/upsert-purchase-order/upsert-purchase-order.component.ts
@@ -99,10 +99,15 @@ export class UpsertPurchaseOrderComponent implements OnInit, OnDestroy {
       }
 
       //Get Most Recent PO for signatories
+      const getMostRecentPO$ = this.poApi.getMostRecentPurchaseOrder().pipe(
+        catchError((error) => {
+          console.error(error);
+          return of(false);
+        })
+      );
+
       const recentPo = (await firstValueFrom(
-        this.poApi
-          .getMostRecentPurchaseOrder()
-          .pipe(catchError(() => of(false)))
+        getMostRecentPO$
       )) as unknown as PurchaseOrder;
 
       if (!recentPo) {

--- a/src/app/modules/portal/pages/purchase-order/pages/upsert-purchase-order/upsert-purchase-order.component.ts
+++ b/src/app/modules/portal/pages/purchase-order/pages/upsert-purchase-order/upsert-purchase-order.component.ts
@@ -18,7 +18,7 @@ import {
   TransformReference,
 } from '@app/shared/services/data/transform-data/transform-data.service';
 import { isEmpty } from '@app/shared/utils/objectUtil';
-import { firstValueFrom } from 'rxjs';
+import { catchError, firstValueFrom, of } from 'rxjs';
 
 interface Pricing {
   STATIC: {
@@ -100,8 +100,10 @@ export class UpsertPurchaseOrderComponent implements OnInit, OnDestroy {
 
       //Get Most Recent PO for signatories
       const recentPo = (await firstValueFrom(
-        this.poApi.getMostRecentPurchaseOrder()
-      )) as PurchaseOrder;
+        this.poApi
+          .getMostRecentPurchaseOrder()
+          .pipe(catchError(() => of(false)))
+      )) as unknown as PurchaseOrder;
 
       if (!recentPo) {
         this.loading = false;

--- a/src/app/shared/forms/out-delivery-form/out-delivery-form.component.ts
+++ b/src/app/shared/forms/out-delivery-form/out-delivery-form.component.ts
@@ -221,8 +221,16 @@ export class OutDeliveryFormComponent implements OnInit, OnDestroy {
       );
     const response = (await firstValueFrom(getOutDeliveryById$)) as any;
 
-    if (!response) return;
+    if (!response) {
+      this.snackbarService.openErrorSnackbar(
+        'Error',
+        'No Out Delivery was found for the provided ID.'
+      );
+      this.router.navigate(['portal', 'out-delivery']);
+      return;
+    }
 
+    //If DR has PO, get its PO
     if (response._purchaseOrderId) {
       const purchaseOrder = await this._getPoById(response._purchaseOrderId);
       this.searchPoControl.patchValue(purchaseOrder);
@@ -597,9 +605,15 @@ export class OutDeliveryFormComponent implements OnInit, OnDestroy {
         }
       }
 
-      const recentDR = (await firstValueFrom(
-        this.outdeliveryApi.getMostRecentOutDelivery()
-      )) as OutDelivery;
+      //Get Recent DR for signatories
+      const getRecentDR$ = this.outdeliveryApi.getMostRecentOutDelivery().pipe(
+        catchError((error) => {
+          console.error(error);
+          return of(false);
+        })
+      );
+
+      const recentDR = (await firstValueFrom(getRecentDR$)) as OutDelivery;
 
       if (!recentDR) {
         return;

--- a/src/app/shared/forms/soa-form/soa-form.component.ts
+++ b/src/app/shared/forms/soa-form/soa-form.component.ts
@@ -322,11 +322,19 @@ export class SoaFormComponent implements OnInit, OnDestroy {
     );
     const soaFromResponse = (await firstValueFrom(getSoaById$)) as any;
 
-    if (!soaFromResponse) return;
+    if (!soaFromResponse) {
+      this.snackbarService.openErrorSnackbar(
+        'Error',
+        `No SOA was found for the provided ID.`
+      );
+      this.router.navigate(['portal', 'soa']);
+      return;
+    }
 
     createdSoa = soaFromResponse;
     this.soa = createdSoa;
 
+    //If SOA has PO, get its PO
     if (soaFromResponse._purchaseOrderId) {
       const purchaseOrder = await this._getPoById(
         soaFromResponse._purchaseOrderId
@@ -729,6 +737,7 @@ export class SoaFormComponent implements OnInit, OnDestroy {
         }
       }
 
+      //Get recent SOA for signatories
       const getRecentSoa$ = this.soaApi.getMostRecentSoa().pipe(
         takeUntil(this.destroyed$),
         catchError((error) => {
@@ -742,6 +751,7 @@ export class SoaFormComponent implements OnInit, OnDestroy {
       if (!recentSOA) {
         return;
       }
+
       createSoa['signatories'] = recentSOA.signatories;
       this._autoFillForm(createSoa);
     }


### PR DESCRIPTION
*** DESCRIPTION ***

Feature/PO
- added catchError to api call getRecentPO to proceed to create PO form

Feature/SOA
- added error handling that returns to SOA list if the SOA ID used in update found no data

Feature/OutDelivery
- added error handling that returns to DR list if the DR ID used in update found no data